### PR TITLE
Fixing "list index out of range"

### DIFF
--- a/byp4xx.py
+++ b/byp4xx.py
@@ -30,8 +30,11 @@ def curl_code_response(options_var, payload_var):
 	else:
 		code = code.split('\n',1)[0]
 	"""
-	code = code.split('\n',1)[0]	
-	status = code.split(" ")[1] # Status code is in second position
+	try:
+		code = code.split('\n',1)[0]	
+		status = code.split(" ")[1] # Status code is in second position
+	except:
+		return "Response Error"
 		
 	#200=GREEN
 	if status == "200":


### PR DESCRIPTION
The current script cannot split on invalid response codes, so it gives list "index out of range" and the script exits.

This script has been changed to use Try/Catch and now it works